### PR TITLE
Fast signed distance to mesh query

### DIFF
--- a/python/PyAABB.cpp
+++ b/python/PyAABB.cpp
@@ -100,5 +100,30 @@ void init_BVH(py::module &m) {
                         squared_dists,
                         closest_face_indices,
                         closest_points);
+                })
+        .def("lookup_signed",
+                [](BVHEngine::Ptr tree, const MatrixFr& points, 
+                  const MatrixFr& face_normals,
+                  const MatrixFr& vertex_normals,
+                  const MatrixFr& edge_normals,
+                  const VectorI& edge_map) {
+                VectorF signed_dists;
+                VectorI closest_face_indices;
+                MatrixFr closest_points, closest_face_normals;
+                tree->lookup_signed(
+                        points,
+                        face_normals,
+                        vertex_normals,
+                        edge_normals,
+                        edge_map,
+                        signed_dists,
+                        closest_face_indices,
+                        closest_points,
+                        closest_face_normals);
+                return std::make_tuple(
+                        signed_dists,
+                        closest_face_indices,
+                        closest_points,
+                        closest_face_normals);
                 });
 }

--- a/python/PyIGL.cpp
+++ b/python/PyIGL.cpp
@@ -8,6 +8,9 @@
 #include <Core/EigenTypedef.h>
 #include <IGL/HarmonicSolver.h>
 #include <igl/unique_rows.h>
+#include <igl/per_face_normals.h>
+#include <igl/per_vertex_normals.h>
+#include <igl/per_edge_normals.h>
 
 namespace py = pybind11;
 using namespace PyMesh;
@@ -49,5 +52,30 @@ void init_IGL(py::module &m) {
             VectorI IA, IC;
             igl::unique_rows(A, C, IA, IC);
             return std::make_tuple(C, IA, IC);
+            });
+
+    m.def("face_normals",
+            [](const MatrixFr& V, const MatrixIr& F) {
+            MatrixFr FN;
+            igl::per_face_normals(V, F, FN);
+            return FN;
+            });
+
+    m.def("vertex_normals",
+            [](const MatrixFr& V, const MatrixIr& F, const MatrixFr& FN) {
+            MatrixFr VN;
+            igl::per_vertex_normals(
+                V, F, igl::PER_VERTEX_NORMALS_WEIGHTING_TYPE_ANGLE, FN, VN);
+            return VN;
+            });
+
+    m.def("edge_normals",
+            [](const MatrixFr& V, const MatrixIr& F, const MatrixFr& FN) {
+            MatrixFr EN;
+            MatrixIr E;
+            VectorI EMAP;
+            igl::per_edge_normals(
+                V, F, igl::PER_EDGE_NORMALS_WEIGHTING_TYPE_UNIFORM, FN, EN, E, EMAP);
+            return std::make_tuple(EN, E, EMAP);
             });
 }

--- a/python/pymesh/__init__.py
+++ b/python/pymesh/__init__.py
@@ -41,13 +41,14 @@ from .tetrahedralize import tetrahedralize
 from .matrixio import load_matrix, save_matrix
 from .minkowski_sum import minkowski_sum
 from .cell_partition import partition_into_cells
-from .aabb_tree import AABBTree, AABBTree2, BVH, distance_to_mesh, do_intersect
+from .aabb_tree import AABBTree, AABBTree2, BVH, distance_to_mesh, signed_distance_to_mesh, do_intersect
 from .triangle import triangle
 from .triangulate import triangulate_beta, refine_triangulation
 from .wires import *
 from .snap_rounding import snap_rounding
 from .SparseSolver import SparseSolver
 from .igl_utils import unique_rows
+from .igl_utils import face_normals, vertex_normals, edge_normals
 
 from .map_attributes import map_vertex_attribute
 from .map_attributes import map_face_attribute
@@ -87,6 +88,7 @@ __all__ = [
         "AABBTree",
         "AABBTree2",
         "distance_to_mesh",
+        "signed_distance_to_mesh",
         "do_intersect",
         "VoxelGrid",
         "HarmonicSolver",
@@ -99,7 +101,10 @@ __all__ = [
         "map_face_attribute",
         "map_corner_attribute",
         "refine_triangulation",
-        "unique_rows"
+        "unique_rows",
+        "face_normals",
+        "vertex_normals",
+        "edge_normals"
         ];
 __all__ += meshutils.__all__;
 __all__ += misc.__all__;

--- a/python/pymesh/aabb_tree.py
+++ b/python/pymesh/aabb_tree.py
@@ -59,6 +59,10 @@ class BVH:
         sq_dists, face_indices, closest_pts = self.__raw_bvh.lookup(pts);
         return sq_dists.squeeze(), face_indices.squeeze(), closest_pts;
 
+    def lookup_signed(self, pts, fn, vn, en, emap):
+        signed_dists, face_indices, closest_pts, face_normals = self.__raw_bvh.lookup_signed(pts, fn, vn, en, emap);
+        return signed_dists, face_indices.squeeze(), closest_pts, face_normals.squeeze();
+
 
 def distance_to_mesh(mesh, pts, engine="auto", bvh=None):
     """ Compute the distance from a set of points to a mesh.
@@ -86,6 +90,74 @@ def distance_to_mesh(mesh, pts, engine="auto", bvh=None):
         bvh.load_mesh(mesh);
     squared_distances, face_indices, closest_points = bvh.lookup(pts);
     return squared_distances, face_indices, closest_points;
+
+def signed_distance_to_mesh(mesh, pts, engine="igl", bvh=None):
+    """ Compute the signed distance from a set of points to a mesh.
+
+    Args:
+        mesh (:class:`Mesh`): A input mesh.
+        pts (:class:`numpy.ndarray`): A :math:`N \\times dim` array of query
+            points.
+        engine (``string``): BVH engine name. Valid choices are "cgal",
+            "geogram", "igl" if all dependencies are used. The default is
+            "auto" where an available engine is automatically picked.
+        bvh (:class:`BVH`): BVH engine instance (optional)
+
+    Returns:
+        Three values are returned.
+
+            * ``signed_distances``: signed (unsquared) distances from each
+                                    point to mesh.
+            * ``face_indices``  : the closest face to each point.
+            * ``closest_points``: the point on mesh that is closest to each
+                                  query point.
+    """
+
+    if not bvh:
+        bvh = BVH(engine, mesh.dim);
+        bvh.load_mesh(mesh);
+
+    # get face normals
+    try:
+        face_normals = np.reshape(mesh.get_attribute("face_normals"),
+                                  np.int32(mesh.get_attribute("face_normals_shape")))
+    except RuntimeError:
+        face_normals = PyMesh.face_normals(mesh.vertices, mesh.faces)
+        mesh.add_attribute("face_normals")
+        mesh.add_attribute("face_normals_shape")
+        mesh.set_attribute("face_normals", face_normals)
+        mesh.set_attribute("face_normals_shape", np.array(face_normals.shape))
+
+    # get vertex normals
+    try:
+        vertex_normals = np.reshape(mesh.get_attribute("vertex_normals"),
+                                    np.int32(mesh.get_attribute("vertex_normals_shape")))
+    except RuntimeError:
+        vertex_normals = PyMesh.vertex_normals(mesh.vertices, mesh.faces, face_normals)
+        mesh.add_attribute("vertex_normals")
+        mesh.add_attribute("vertex_normals_shape")
+        mesh.set_attribute("vertex_normals", vertex_normals)
+        mesh.set_attribute("vertex_normals_shape", np.array(vertex_normals.shape))
+
+    # get edge normals
+    try:
+        edge_normals = np.reshape(mesh.get_attribute("edge_normals"),
+                                  np.int32(mesh.get_attribute("edge_normals_shape")))
+        edge_map = np.reshape(np.int32(mesh.get_attribute("edge_map")),
+                              np.int32(mesh.get_attribute("edge_map_shape")))
+    except RuntimeError:
+        edge_normals, _, edge_map = PyMesh.edge_normals(mesh.vertices, mesh.faces, face_normals)
+        mesh.add_attribute("edge_normals")
+        mesh.add_attribute("edge_map")
+        mesh.add_attribute("edge_normals_shape")
+        mesh.add_attribute("edge_map_shape")
+        mesh.set_attribute("edge_normals", edge_normals)
+        mesh.set_attribute("edge_map", edge_map)
+        mesh.set_attribute("edge_normals_shape", np.array(edge_normals.shape))
+        mesh.set_attribute("edge_map_shape", np.array(edge_map.shape))
+
+    signed_distances, face_indices, closest_points, face_normals = bvh.lookup_signed(pts, face_normals, vertex_normals, edge_normals, edge_map);
+    return signed_distances, face_indices, closest_points, face_normals;
 
 def do_intersect(mesh, nodes, elements):
     """ Check if each element intersects the mesh.

--- a/python/pymesh/aabb_tree.py
+++ b/python/pymesh/aabb_tree.py
@@ -60,7 +60,7 @@ class BVH:
         return sq_dists.squeeze(), face_indices.squeeze(), closest_pts;
 
 
-def distance_to_mesh(mesh, pts, engine="auto"):
+def distance_to_mesh(mesh, pts, engine="auto", bvh=None):
     """ Compute the distance from a set of points to a mesh.
 
     Args:
@@ -70,6 +70,7 @@ def distance_to_mesh(mesh, pts, engine="auto"):
         engine (``string``): BVH engine name. Valid choices are "cgal",
             "geogram", "igl" if all dependencies are used. The default is
             "auto" where an available engine is automatically picked.
+        bvh (:class:`BVH`): BVH engine instance (optional)
 
     Returns:
         Three values are returned.
@@ -80,8 +81,9 @@ def distance_to_mesh(mesh, pts, engine="auto"):
                                   query point.
     """
 
-    bvh = BVH(engine, mesh.dim);
-    bvh.load_mesh(mesh);
+    if not bvh:
+        bvh = BVH(engine, mesh.dim);
+        bvh.load_mesh(mesh);
     squared_distances, face_indices, closest_points = bvh.lookup(pts);
     return squared_distances, face_indices, closest_points;
 

--- a/python/pymesh/igl_utils.py
+++ b/python/pymesh/igl_utils.py
@@ -1,2 +1,4 @@
 from PyMesh import unique_rows
-
+from PyMesh import face_normals
+from PyMesh import vertex_normals
+from PyMesh import edge_normals

--- a/tools/BVH/BVHEngine.cpp
+++ b/tools/BVH/BVHEngine.cpp
@@ -45,15 +45,22 @@ BVHEngine::Ptr BVHEngine::create(const std::string& engine_name, size_t dim) {
 #endif
 #if WITH_IGL
     if (engine_name == "igl") {
-        switch (dim) {
-            case 2:
-                return std::make_shared<IGL::AABBTree<2>>();
-            case 3:
-                return std::make_shared<IGL::AABBTree<3>>();
-            default:
-                throw NotImplementedError("Only 2D and 3D meshes are supported");
+        if (dim != 3) {
+            throw NotImplementedError(
+                    "Only 3D meshes are supported by IGL BVH");
         }
+        return std::make_shared<IGL::AABBTree<3>>();
     }
+//     if (engine_name == "igl") {
+//         switch (dim) {
+//             case 2:
+//                 return std::make_shared<IGL::AABBTree<2>>();
+//             case 3:
+//                 return std::make_shared<IGL::AABBTree<3>>();
+//             default:
+//                 throw NotImplementedError("Only 2D and 3D meshes are supported");
+//         }
+//     }
 #endif
     throw NotImplementedError("BVH Engine (" + engine_name
             + ") is not supported.");

--- a/tools/BVH/BVHEngine.h
+++ b/tools/BVH/BVHEngine.h
@@ -53,6 +53,23 @@ class BVHEngine {
             throw NotImplementedError("BVH algorithm is not implemented");
         }
 
+        /**
+         * For each point in points, lookup the closest points on mesh and the
+         * corresponding signed (un-squared) distances and faces.
+         * Warning: only work with IGL engine
+         */
+        virtual void lookup_signed(const MatrixFr& points,
+                const MatrixFr& face_normals,
+                const MatrixFr& vertex_normals,
+                const MatrixFr& edge_normals,
+                const VectorI& edge_map,
+                VectorF& signed_distances,
+                VectorI& closest_faces,
+                MatrixFr& closest_points,
+                MatrixFr& closest_face_normals) const {
+            throw NotImplementedError("BVH algorithm is not implemented");
+        }
+
     protected:
         MatrixFr m_vertices;
         MatrixIr m_faces;

--- a/tools/BVH/IGL/AABBTree.h
+++ b/tools/BVH/IGL/AABBTree.h
@@ -6,6 +6,7 @@
 #include <BVH/BVHEngine.h>
 
 #include <igl/AABB.h>
+#include <igl/signed_distance.h>
 
 namespace PyMesh {
 namespace IGL {
@@ -29,6 +30,20 @@ class AABBTree : public BVHEngine {
                 MatrixFr& closest_points) const {
             m_tree.squared_distance(m_vertices, m_faces, points,
                     squared_distances, closest_faces, closest_points);
+        }
+
+        virtual void lookup_signed(const MatrixFr& points,
+                const MatrixFr& face_normals,
+                const MatrixFr& vertex_normals,
+                const MatrixFr& edge_normals,
+                const VectorI& edge_map,
+                VectorF& signed_distances,
+                VectorI& closest_faces,
+                MatrixFr& closest_points,
+                MatrixFr& closest_face_normals) const {
+          igl::signed_distance_pseudonormal(points, m_vertices, m_faces, m_tree,
+              face_normals, vertex_normals, edge_normals, edge_map,
+              signed_distances, closest_faces, closest_points, closest_face_normals);
         }
 
     private:


### PR DESCRIPTION
Two modifications have been made to speedup PyMesh's distance-to-mesh queries.

1. Allowed BVH to be an optional argument for "distance_to_mesh" function. If users provide a precomputed "BVH" instance, the creation of such an instance inside the "distance_to_mesh" function will be skipped. This can save a lot of computational time if users need to call "distance_to_mesh" many times with the same mesh in their applications. For instance, in the particle simulations, one may need to calculate the particles' distances to mesh for every simulation step for thousands or millions of steps.

2. Extended PyMesh's capability of efficiently computing signed distance to mesh. Originally, PyMesh does not directly support "signed_distance_to_mesh" queries. Users may achieve a similar functionality by combining "distance_to_mesh" and "compute_winding_number". However, "compute_winding_number" is extremely time consuming for complex meshes. The present implementations have provided a "signed_distance_to_mesh" interface for signed distance to mesh queries. This "signed_distance_to_mesh" is implemented based on "igl::signed_distance_pseudonormal" from the Libigl library. (Note "igl::signed_distance_pseudonormal" requires mesh to be water tight.) Over 100x speedup has been seen in our tests with meshes having ~50k vertices and ~100k triangular elements, compared to those using the "compute_winding_number" and "distance_to_mesh" combination.